### PR TITLE
Add glyph and font name to VariantsWindow

### DIFF
--- a/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
@@ -250,7 +250,10 @@ GSGlyphReference.__eq__ = objc.python_method(__GSGlyphReference__eq__)
 class VariantsWindow:
     def __init__(self, glyph):
         self._glyph = glyph
-        self._window = window = vanilla.Window((650, 400), "MATH Variants")
+        self._window = window = vanilla.Window(
+            (650, 400),
+            f"MATH Variants for ‘{self._glyph.name}’ from {glyph.parent.familyName}",
+        )
         window.tabs = vanilla.Tabs((10, 10, -10, -10), ["Vertical", "Horizontal"])
 
         self._emptyRow = {"g": "", "s": 0, "e": 0, "f": False}


### PR DESCRIPTION
For better orientation, this displays the glyph and font family name in the title bar of the VariantsWindow.

![Bildschirmfoto 2023-07-10 um 16 04 06](https://github.com/Nagwa-Limited-Community/Glyphs-MATH-Plugin/assets/3185950/9e9d125a-8252-4282-853b-12b52c95dc2b)
