### PR TITLE
Fix horizontal assemblies

### DIFF
--- a/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
@@ -870,13 +870,12 @@ class MATHPlugin(GeneralPlugin):
             overlap = userData.get("MinConnectorOverlap", 0)
             table.MathVariants.MinConnectorOverlap = overlap
 
-        for variants, assemblies in (
-            (vvariants, vassemblies),
-            (hvariants, hassemblies),
+        for vertical, variants, assemblies in (
+            (True, vvariants, vassemblies),
+            (False, hvariants, hassemblies),
         ):
             if not variants and not assemblies:
                 continue
-            vertical = variants == vvariants
             coverage = list(variants.keys()) + list(assemblies.keys())
             coverage = otl.buildCoverage(coverage, glyphMap)
             constructions = []


### PR DESCRIPTION
I tried to add horizontal assemblies for elongating arrows. I noticed those are written as vertical instead of horizontal variants in the font, overwriting any existing vertical variants.

This change fixes the issue.