### PR TITLE
Fix for when only "ExtendedShapeCoverage" is added

### DIFF
--- a/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/plugin.py
@@ -821,7 +821,7 @@ class MATHPlugin(GeneralPlugin):
         glyphOrder = ttFont.getGlyphOrder()
         glyphMap = {n: i for i, n in enumerate(glyphOrder)}
 
-        if italic or accent:
+        if italic or accent or extended:
             info = table.MathGlyphInfo = otTables.MathGlyphInfo()
             info.populateDefaults()
 
@@ -861,7 +861,7 @@ class MATHPlugin(GeneralPlugin):
                 records.append(record)
 
         if extended:
-            table.MathGlyphInfo.ExtendedShapeCoverage = otl.buildCoverage(
+            info.ExtendedShapeCoverage = otl.buildCoverage(
                 extended, glyphMap
             )
 


### PR DESCRIPTION
When no italic or accent data was present in the MathGlyphInfo, adding the ExtendedShapeCoverage would fail.