### PR TITLE
Some fixes (drawing, production names)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-ignore=
+extend-ignore =
   E117,
   E722,
   W191

--- a/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/build.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/build.py
@@ -80,14 +80,14 @@ class MathTableBuilder:
             name = productionMap[glyph.name]
             varData = glyph.userData.get(VARIANTS_ID, {})
             if vVars := varData.get(V_VARIANTS_ID):
-                vVars = [str(n) for n in vVars]
+                vVars = [productionMap[str(n)] for n in vVars]
                 vVariants[name] = [
                     (n, _bboxHeight(font.glyphs[n].layers[0])) for n in vVars
                 ]
                 if glyph.userData[EXTENDED_SHAPE_ID]:
                     extended.update(str(v) for v in vVars)
             if hVars := varData.get(H_VARIANTS_ID):
-                hVars = [str(n) for n in hVars]
+                hVars = [productionMap[str(n)] for n in hVars]
                 hVariants[name] = [
                     (n, _bboxWidth(font.glyphs[n].layers[0])) for n in hVars
                 ]
@@ -97,7 +97,11 @@ class MathTableBuilder:
             if vAssembly := varData.get(V_ASSEMBLY_ID):
                 vAssemblies[name] = [
                     [
-                        (str(part[0]), *part[1:], _bboxHeight(part[0].glyph.layers[0]))
+                        (
+                            productionMap[str(part[0])],
+                            *part[1:],
+                            _bboxHeight(part[0].glyph.layers[0]),
+                        )
                         for part in vAssembly
                     ],
                     italic.pop(str(vAssembly[-1][0]), 0),
@@ -105,7 +109,11 @@ class MathTableBuilder:
             if hAssembly := varData.get(H_ASSEMBLY_ID):
                 hAssemblies[name] = [
                     [
-                        (str(part[0]), *part[1:], _bboxWidth(part[0].glyph.layers[0]))
+                        (
+                            productionMap[str(part[0])],
+                            *part[1:],
+                            _bboxWidth(part[0].glyph.layers[0]),
+                        )
                         for part in hAssembly
                     ],
                     italic.pop(str(hAssembly[-1][0]), 0),

--- a/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/drawing.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/drawing.py
@@ -134,6 +134,9 @@ class MathDrawing:
             save()
             translate(x, y)
             variantLayer = gl(variant).layers[layer.layerId]
+            if variantLayer is None:
+                continue
+
             path = variantLayer.completeBezierPath
             path.setLineWidth_(width)
             path.stroke()
@@ -162,6 +165,8 @@ class MathDrawing:
             save()
             translate(x, y)
             partLayer = gl(gRef).layers[layer.layerId]
+            if partLayer is None:
+                continue
             path = partLayer.completeBezierPath
             path.setLineWidth_(width)
             path.stroke()
@@ -196,6 +201,9 @@ class MathDrawing:
             prev = end
 
             partLayer = gl(gRef).layers[layer.layerId]
+            if partLayer is None:
+                continue
+
             w, h = _getMetrics(partLayer)
             if vertical:
                 y -= overlap


### PR DESCRIPTION
I updated an older font project that used a previous version of the plugin, and found I needed some fixes to make everything work:

- While drawing the glyph assemblies, if a layer was selected that does not exist in any glyph referenced by the assemblies (e.g. a backup layer), an error was thrown
- Compiling the MATH table failed because the names referenced in variants and assemblies weren't converted to production names
- And a small fix-up for the .flake8 file, the previous `ignore` setting apparently didn't have any effect