### PR TITLE
Check constants' values instead of the dict itself

### DIFF
--- a/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/build.py
+++ b/MATHPlugin.glyphsPlugin/Contents/Resources/OpenTypeMathPlugin/build.py
@@ -121,7 +121,7 @@ class MathTableBuilder:
 
         if not any(
             [
-                constants,
+                *constants.values(),
                 italic,
                 accent,
                 vVariants,


### PR DESCRIPTION
Check if the constants' values are falsy when deciding whether to build the MATH table.

Previously, the dict keys were used to decide whether to build a math table, so the MATH table was built even if all constants were 0.